### PR TITLE
docs: add cloud humor to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Hydro integrates naturally with standard Rust constructs and IDEs, providing typ
 # Contributing
 
 For Hydro development setup and contribution info, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+☁️ **Cloud Humor**: Why don't programmers like AWS billing? Because the only thing that scales faster than their infrastructure is their bill!


### PR DESCRIPTION
This PR adds a lighthearted cloud humor section to the README to bring some fun to the documentation.

## Changes
- Added cloud humor joke about AWS billing at the end of README.md

## Testing
- [x] README renders correctly with the new content