### PR TITLE
docs: update README author to zoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- Changelog created by Kiro to track project changes -->
+
+## [Unreleased]
+
+### Changed
+- Updated README.md author attribution from "the Hydro Project" to "zoo" (by Kiro)
+- Created CHANGELOG.md to document project changes (by Kiro)
+
+**Date:** 2025-01-21
+**Author:** Kiro

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ See [CITATION.cff](CITATION.cff) for additional citation formats.
 
 ---
 
+<!-- Author updated to "zoo" as requested -->
 <p align="center">
-Built with ❤️ by the <a href="https://hydro.run">Hydro Project</a>
+Built with ❤️ by <a href="https://hydro.run">zoo</a>
 </p>


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Changes

- Updated the author attribution at the bottom of README.md from "the Hydro Project" to "zoo"
- Created CHANGELOG.md documenting this change

## What was tested

Verified the commit is clean and both files are properly formatted.